### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/build-release-linux.yml
+++ b/.github/workflows/build-release-linux.yml
@@ -21,22 +21,17 @@ jobs:
           docker run --rm -v $(pwd)/dist:/dist nbis-builder bash -c "apt-get install -y zip && cd /build && zip -r /dist/nbis-linux-amd64.zip *"
 
       - name: Create Release
-        uses: actions/create-release@v1
-        id: create_release
+        uses: bruceadams/get-release@v1.3.2
+        id: get_release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: false
-          prerelease: false
 
       - name: Upload Asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
           asset_path: ./dist/nbis-linux-amd64.zip
           asset_name: nbis-linux-amd64.zip
           asset_content_type: application/zip


### PR DESCRIPTION
We don't need to create release when trigger is on new tag.